### PR TITLE
Removed the claim status column and changed to assigned datacentre

### DIFF
--- a/datamad2/tables.py
+++ b/datamad2/tables.py
@@ -17,7 +17,7 @@ class GrantTable(tables.Table):
     grant_ref = tables.LinkColumn(viewname='grant_detail', args=[A('importedgrant__pk')], verbose_name='Grant Reference')
     routing_classification = tables.TemplateColumn(template_name='datamad2/fields/routing_classification_field.html')
     date_added = tables.DateTimeColumn(accessor='importedgrant__creation_date', format='d M Y')
-    claim_status = tables.TemplateColumn(accessor='claimed', template_name='datamad2/fields/claim_status_field.html', attrs={'td':{'class': 'align-middle text-center'}})
+    assigned_datacentre = tables.TemplateColumn(accessor='assigned_data_centre', template_name='datamad2/fields/assigned_datacentre_field.html', attrs={'td':{'class': 'align-middle text-center'}})
 
     class Meta:
         model = Grant
@@ -37,12 +37,6 @@ class GrantTable(tables.Table):
             'importedgrant__grant_holder',
             'routing_classification',
             'date_added',
-            'claim_status',
+            'assigned_datacentre',
             '...'
         )
-
-
-class DataCentreGrantTable(GrantTable):
-
-    class Meta(GrantTable.Meta):
-        exclude=('claim_status',)

--- a/datamad2/tables.py
+++ b/datamad2/tables.py
@@ -14,10 +14,23 @@ from django_tables2.utils import A
 
 
 class GrantTable(tables.Table):
-    grant_ref = tables.LinkColumn(viewname='grant_detail', args=[A('importedgrant__pk')], verbose_name='Grant Reference')
-    routing_classification = tables.TemplateColumn(template_name='datamad2/fields/routing_classification_field.html')
-    date_added = tables.DateTimeColumn(accessor='importedgrant__creation_date', format='d M Y')
-    assigned_datacentre = tables.TemplateColumn(accessor='assigned_data_centre', template_name='datamad2/fields/assigned_datacentre_field.html', attrs={'td':{'class': 'align-middle text-center'}})
+    grant_ref = tables.LinkColumn(
+        viewname='grant_detail',
+        args=[A('importedgrant__pk')],
+        verbose_name='Grant Reference'
+    )
+    routing_classification = tables.TemplateColumn(
+        template_name='datamad2/fields/routing_classification_field.html'
+    )
+    date_added = tables.DateTimeColumn(
+        accessor='importedgrant__creation_date',
+        format='d M Y'
+    )
+    assigned_datacentre = tables.TemplateColumn(
+        accessor='assigned_data_centre',
+        template_name='datamad2/fields/assigned_datacentre_field.html',
+        attrs={'td':{'class': 'align-middle text-center'}}
+    )
 
     class Meta:
         model = Grant

--- a/datamad2/templates/datamad2/fields/assigned_datacentre_field.html
+++ b/datamad2/templates/datamad2/fields/assigned_datacentre_field.html
@@ -1,5 +1,5 @@
 {% if value %}
-    CLAIMED
+    {{ value }}
 {% else %}
         <button data-id="{{ record.pk }}" data-user="{{ request.user.data_centre.name }}"
                 class="btn btn-primary claim-btn" id="claim-button"> CLAIM

--- a/datamad2/views.py
+++ b/datamad2/views.py
@@ -14,7 +14,7 @@ from django.core.exceptions import ValidationError
 from django.views.generic.edit import FormView
 import re
 from django.core.exceptions import ObjectDoesNotExist
-from datamad2.tables import GrantTable, DataCentreGrantTable
+from datamad2.tables import GrantTable
 
 
 class FormatError(Exception):
@@ -130,11 +130,6 @@ class FacetedGrantListView(LoginRequiredMixin, FacetedSearchView):
     template_name = 'datamad2/grant_list.html'
 
     def get_table(self, context):
-        selected_facets = self.request.GET.getlist('selected_facets')
-        if selected_facets:
-            for facet in selected_facets:
-                if facet.startswith('assigned_datacentre'):
-                    return DataCentreGrantTable(data=[item.object for item in context['page_obj'].object_list], orderable=False)
         return GrantTable(data=[item.object for item in context['page_obj'].object_list], orderable=False)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
I wasn't happy with the behaviour of the table when you filter by datacentre as this leads to columns disappearing and reappearing. I get the point that a column saying CLAIMED is not necessary when you are viewing only grants by your datacentre so thought perhaps changing the column might address both issues.

1. Make the information in the column useful in the context
2. Remove "Unexplained" behaviour of disappearing columns
