### PR TITLE
Modify document naming convention

### DIFF
--- a/datamad2/templates/datamad2/document_upload.html
+++ b/datamad2/templates/datamad2/document_upload.html
@@ -8,7 +8,7 @@
         {% csrf_token %}
         <div class="card card-shaded">
             <div class="card-body">
-                <h4><label> Upload Document </label></h4>
+                <h4><label> Upload Document for {{ grant.grant_ref }}</label></h4>
                 <p>{{ form | crispy }}</p>
                 <p>
                     <button type="submit" class="save btn btn-primary" id="claim">Upload</button>

--- a/datamad2/templates/datamad2/grant_detail.html
+++ b/datamad2/templates/datamad2/grant_detail.html
@@ -109,7 +109,7 @@
                 </tr>
                 <tr>
                     <th>Overall Score</th>
-                    <td>{{ imported_grant.overall_score|default_if_none:"N/A" }} </td>
+                    <td>{{ imported_grant.overall_score }} </td>
                 </tr>
                 <tr>
                     <th>Facility</th>

--- a/datamad2/templates/datamad2/includes/document_naming_convention.html
+++ b/datamad2/templates/datamad2/includes/document_naming_convention.html
@@ -3,16 +3,19 @@
         File names must follow the format:
     </p>
     <p>
-        GRANT REFERENCE (underscore separated) DOC TYPE
+        &lt;GRANT REFERENCE (underscore separated)&gt;_&lt;DOC TYPE&gt;
         <br>
-        e.g. NE_T000619_1 DMP.pdf
+        e.g. NE_T000619_1_DMP.pdf
     </p>
     <p>
         Document types used are:
     </p>
     <ul>
         <li>
-            DMP - Outline data management plan
+            ODMP - Outline data management plan
+        </li>
+        <li>
+            DMP - Data management plan
         </li>
         <li>
             CFS - Case for support

--- a/datamad2/views.py
+++ b/datamad2/views.py
@@ -17,7 +17,7 @@ from jira_oauth.decorators import jira_access_token_required
 from django.conf import settings
 from django.views.generic.edit import FormView
 
-DOCUMENT_NAMING_PATTERN = re.compile("^(?P<grant_ref>\w*_\w*_\d*) (?P<doc_type>\w*)(?P<extension>\.\w*)$")
+DOCUMENT_NAMING_PATTERN = re.compile("^(?P<grant_ref>\w*_\w*_\d*)_(?P<doc_type>\w*)(?P<extension>\.\w*)$")
 
 
 class FormatError(Exception):
@@ -287,7 +287,7 @@ def document_upload(request, pk):
     else:
         form = DocumentForm(instance=grant)
 
-    return render(request, 'datamad2/document_upload.html', {'form': form})
+    return render(request, 'datamad2/document_upload.html', {'form': form, 'grant': grant})
 
 
 def delete_file(request, pk):


### PR DESCRIPTION
Updated document naming convention to use underscore separation closes #201
Updated document naming convention text to reflect change and made distinction between DMP and ODMP
Updated overall score to display None if no value instead of N/A to make it a little clearer. closes #192