### PR TITLE
use intcomma template tag to add thousand comma separator

### DIFF
--- a/datamad2/templates/datamad2/grant_detail.html
+++ b/datamad2/templates/datamad2/grant_detail.html
@@ -1,5 +1,5 @@
 {% extends 'datamad2/base.html' %}
-{% load static see_more claim_status %}
+{% load static see_more claim_status humanize %}
 
 {% block breadcrumb_items %}
     <li class="breadcrumb-item"><a href="{% url 'grant_list' %}">Home</a></li>
@@ -85,7 +85,7 @@
                     </tr>
                     <tr>
                         <th>Amount Awarded</th>
-                        <td> £ {{ imported_grant.amount_awarded|default_if_none:"N/A" }} </td>
+                        <td> £ {{ imported_grant.amount_awarded|default_if_none:"N/A"| intcomma }} </td>
                     </tr>
                     <tr>
                         <th>Grant Type</th>

--- a/datamadsite/settings.py
+++ b/datamadsite/settings.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.humanize',
 ]
 
 MIDDLEWARE = [
@@ -131,8 +132,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
-USE_THOUSAND_SEPARATOR = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/


### PR DESCRIPTION
Use intcomma template tag instead of `USE_THOUSAND_SEPARATOR = True` as this was adding in a comma to the primary keys of grants/imported grants if they were in the thousands, which was preventing them from being claimed. closes #381 