### PR TITLE
use dmp docs only for dmp agreed

### DIFF
--- a/datamad2/templates/datamad2/grant_detail.html
+++ b/datamad2/templates/datamad2/grant_detail.html
@@ -248,14 +248,15 @@
                         <th>DMP Agreed</th>
                         <td>
                             {% if imported_grant.grant.dmp_agreed %}
-                                {% with doc=imported_grant.grant.document_set.all.first %}
+
+                                {% with doc=dmp_docs.all.first %}
                                     {% if doc %}
-                                    {{ doc.last_modified| date:"dS M Y" }}
+                                    {{ imported_grant.grant.dmp_agreed_date | date:"jS M Y" }}
                                     <br>
                                     <a href="{{ doc.upload.url }}"
                                        download="{{ doc.download_title }}"> {{ doc.title }} </a>
                                     {%  else %}
-                                        {{ imported_grant.grant.dmp_agreed_date | date:"d M Y"}}
+                                        {{ imported_grant.grant.dmp_agreed_date | date:"jS M Y"}}
                                     {% endif %}
                                 {% endwith %}
                             {% else %}


### PR DESCRIPTION
Closes #404 

- Look at dmp documents only for DMP agreed doc
- always show the date the box was ticked (rather than last modified date of document)
- Change date to show e.g. 4th instead of 04th 