### PR TITLE
Filters and Table now have uniform breakpoints

### DIFF
--- a/datamad2/templates/datamad2/base.html
+++ b/datamad2/templates/datamad2/base.html
@@ -176,7 +176,7 @@
                 {% endblock info_panel %}
             {% endblock content_header %}
             {% block content_panel %}
-                <div class="row">
+                <div class="row flex-xl-nowrap">
                     {% block sidebar %}
                     {% endblock sidebar %}
                     {% block content %}


### PR DESCRIPTION
Added class to div containing sidebar and table as seen in image, table now will only shift down when screen is 1200px defined by breakpoint xl.

![image](https://user-images.githubusercontent.com/64157734/127513111-c88d37a7-3a56-48b9-b52d-92dbc65fcbb5.png)
